### PR TITLE
Bump up allowable rspec-rails version to < 7

### DIFF
--- a/validator-matchers.gemspec
+++ b/validator-matchers.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |s|
 
   s.require_paths = ['lib']
 
-  s.add_dependency 'rspec-rails', '>= 3.0', '< 6'
+  s.add_dependency 'rspec-rails', '>= 3.0', '< 7'
 end


### PR DESCRIPTION
Currently the gem is locking `rspec-rails` to < 6. 
This bumps the gemspec to < 7 to address the issue described here in Rails 7.1: 
https://github.com/rspec/rspec-rails/issues/2659 
and was fixed here: 
https://github.com/rspec/rspec-rails/pull/2631